### PR TITLE
Fix schema method

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include README.md
+

--- a/starcraft_data_orm/inject/Injectable.py
+++ b/starcraft_data_orm/inject/Injectable.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 class Injectable(ABC):
     @classmethod
-    @property
     @abstractmethod
     def __tableschema__(cls):
         """Return the schema name. Must be implemented by subclasses."""
@@ -20,7 +19,6 @@ class Injectable(ABC):
     def get_data(cls, obj):
         parameters = defaultdict(lambda: None)
         for variable, value in vars(obj).items():
-            print(f"Processing variable: {variable}, value: {value}")
             if variable in cls.columns:
                 parameters[variable] = value
         print(f"Extracted parameters: {parameters}")

--- a/starcraft_data_orm/warehouse/base.py
+++ b/starcraft_data_orm/warehouse/base.py
@@ -23,5 +23,5 @@ class WarehouseBase:
         """Automatically register subclasses."""
         super().__init_subclass__(**kwargs)
         if hasattr(cls, "process"):
-            name = f"{cls.__tableschema__}.{cls.__tablename__}"
+            name = f"{cls.__tableschema__()}.{cls.__tablename__}"
             __class__.injectable[name] = cls

--- a/starcraft_data_orm/warehouse/config.py
+++ b/starcraft_data_orm/warehouse/config.py
@@ -64,7 +64,7 @@ CurrentConfig = configurations[ENV]
 # Create an async engine
 _engine = create_engine(CurrentConfig.get_connection_string())
 engine = create_async_engine(
-    CurrentConfig.get_connection_string(async_mode=True), echo=True
+    CurrentConfig.get_connection_string(async_mode=True)
 )
 
 # Create a Session Factory

--- a/starcraft_data_orm/warehouse/datapack/ability.py
+++ b/starcraft_data_orm/warehouse/datapack/ability.py
@@ -18,12 +18,11 @@ from starcraft_data_orm.inject import Injectable
 
 class ability(Injectable, WarehouseBase):
     __tablename__ = "ability"
-    __tableschema__ = "datapack"
     __table_args__ = (
         UniqueConstraint(
             "id", "release_string", name="ability_id_release_string_unique"
         ),
-        {"schema": __tableschema__},
+        {"schema": "datapack"},
     )
 
     primary_id = Column(Integer, primary_key=True)
@@ -42,7 +41,6 @@ class ability(Injectable, WarehouseBase):
     basic_command_events = relationship("basic_command_event", back_populates="ability")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "datapack"
 

--- a/starcraft_data_orm/warehouse/datapack/unit_type.py
+++ b/starcraft_data_orm/warehouse/datapack/unit_type.py
@@ -41,7 +41,6 @@ class unit_type(WarehouseBase, Injectable):
     objects = relationship("object", back_populates="unit_type")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "datapack"
 

--- a/starcraft_data_orm/warehouse/events/basic_command_event.py
+++ b/starcraft_data_orm/warehouse/events/basic_command_event.py
@@ -33,7 +33,6 @@ class basic_command_event(Injectable, WarehouseBase):
     ability = relationship("ability", back_populates="basic_command_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/chat_event.py
+++ b/starcraft_data_orm/warehouse/events/chat_event.py
@@ -31,7 +31,6 @@ class chat_event(Injectable, WarehouseBase):
     info = relationship("info", back_populates="chat_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/player_leave_event.py
+++ b/starcraft_data_orm/warehouse/events/player_leave_event.py
@@ -28,7 +28,6 @@ class player_leave_event(Injectable, WarehouseBase):
     info = relationship("info", back_populates="player_leave_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/player_stats_event.py
+++ b/starcraft_data_orm/warehouse/events/player_stats_event.py
@@ -77,7 +77,6 @@ class player_stats_event(Injectable, WarehouseBase):
     info = relationship("info", back_populates="player_stats_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/unit_born_event.py
+++ b/starcraft_data_orm/warehouse/events/unit_born_event.py
@@ -28,7 +28,6 @@ class unit_born_event(Injectable, WarehouseBase):
     unit = relationship("object", back_populates="unit_born_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/unit_died_event.py
+++ b/starcraft_data_orm/warehouse/events/unit_died_event.py
@@ -40,7 +40,6 @@ class unit_died_event(Injectable, WarehouseBase):
     info = relationship("info", back_populates="unit_died_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/unit_done_event.py
+++ b/starcraft_data_orm/warehouse/events/unit_done_event.py
@@ -26,7 +26,6 @@ class unit_done_event(Injectable, WarehouseBase):
     unit = relationship("object", back_populates="unit_done_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/unit_init_event.py
+++ b/starcraft_data_orm/warehouse/events/unit_init_event.py
@@ -26,7 +26,6 @@ class unit_init_event(Injectable, WarehouseBase):
     unit = relationship("object", back_populates="unit_init_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/events/upgrade_complete_event.py
+++ b/starcraft_data_orm/warehouse/events/upgrade_complete_event.py
@@ -28,7 +28,6 @@ class upgrade_complete_event(Injectable, WarehouseBase):
     info = relationship("info", back_populates="upgrade_complete_events")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "events"
 

--- a/starcraft_data_orm/warehouse/replay/info.py
+++ b/starcraft_data_orm/warehouse/replay/info.py
@@ -80,7 +80,6 @@ class info(Injectable, WarehouseBase):
     unit_died_events = relationship("unit_died_event", back_populates="info")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "replay"
 

--- a/starcraft_data_orm/warehouse/replay/map.py
+++ b/starcraft_data_orm/warehouse/replay/map.py
@@ -23,7 +23,6 @@ class map(Injectable, WarehouseBase):
     replays = relationship("info", back_populates="map")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "replay"
 

--- a/starcraft_data_orm/warehouse/replay/object.py
+++ b/starcraft_data_orm/warehouse/replay/object.py
@@ -57,7 +57,6 @@ class object(Injectable, WarehouseBase):
     )
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "replay"
 

--- a/starcraft_data_orm/warehouse/replay/player.py
+++ b/starcraft_data_orm/warehouse/replay/player.py
@@ -62,7 +62,6 @@ class player(Injectable, WarehouseBase):
     )
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "replay"
 

--- a/starcraft_data_orm/warehouse/replay/user.py
+++ b/starcraft_data_orm/warehouse/replay/user.py
@@ -21,7 +21,6 @@ class user(Injectable, WarehouseBase):
     players = relationship("player", back_populates="user")
 
     @classmethod
-    @property
     def __tableschema__(self):
         return "replay"
 


### PR DESCRIPTION
There was a problem with accessing cls.__tableschema__ within the __init_subclass__ form in WarehouseBase class in warehouse/base.py where accessing cls with the property returned the boundmethod and not the return value. Apparently some elements, like @property, are not resolved at this state of class creation. 

In order to circumvent this problem, we've removed the property decorator and access the return value of cls.__tableschema__ through a call.